### PR TITLE
Find correct local IP address

### DIFF
--- a/Utils.cs
+++ b/Utils.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace YeelightController
@@ -38,12 +39,20 @@ namespace YeelightController
 
         public static IPAddress GetLocalIPAddress()
         {
-            var host = Dns.GetHostEntry(Dns.GetHostName());
-            foreach (var ip in host.AddressList)
+            foreach (NetworkInterface ni in NetworkInterface.GetAllNetworkInterfaces())
             {
-                if (ip.AddressFamily == AddressFamily.InterNetwork)
+                var addr = ni.GetIPProperties().GatewayAddresses.FirstOrDefault();
+                if (addr != null && !addr.Address.ToString().Equals("0.0.0.0"))
                 {
-                    return ip;
+                    if (ni.NetworkInterfaceType == NetworkInterfaceType.Wireless80211 || ni.NetworkInterfaceType == NetworkInterfaceType.Ethernet)
+                    {
+                        foreach (UnicastIPAddressInformation ip in ni.GetIPProperties().UnicastAddresses)
+                        {
+                            if (ip.Address.AddressFamily == AddressFamily.InterNetwork) {
+                                return ip.Address;
+                            }
+                        }
+                    }
                 }
             }
             throw new Exception("Local IP Address Not Found!");


### PR DESCRIPTION
The original code to determine the local IP address fails when you have a virtual network for VMs. This PR uses the [NetworkInterface API](https://msdn.microsoft.com/en-us/library/system.net.networkinformation.networkinterface(v=vs.110).aspx) to find the correct local IP address (the proposed code originates from [this StackOverflow answer](https://stackoverflow.com/a/25553311/4747).)
